### PR TITLE
Fix crashes

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -44,10 +44,12 @@
 
 ## Spells
 * Leveled spells with a casting cost of a bonus action block characters from casting another leveled spell on the same turn. Casting a leveled spell that doesn't require a bonus action will also block casting a leveled bonus action spell after ⚙️ `spells_bonusAction`
+  - **_Currently, due to a bug crashing the game, only players are bound by this rule_**
   - _Multiple spells with a casting cost of an Action is still allowed (by the likes of Action Surge)_
   - _The restriction includes Quickened Spell (Metamagic) and spells from Class/Race or Items that are proper spells (even without a spell slot cost)_
   - _Due to an technical limitation, scrolls for spells your character don't know inside a container (such as a backpack) can bypass this rule, so can scrolls send to the character after they already cast a spell on their turn_
 * Call Lightning creates a storm area, inside which the caster can target a smaller area to deal damage each turn
+* Chromatic Orb deals 3d8 base damage and no longer create surfaces. It can still interact with surfaces if targeting the surface directly (for cold, fire and lightning versions)
 * Feign Death provides a Dismiss spell to the caster
 * Find Familiar
   - Base summons (not the ones granted by Pact of the Chain) had all their attacks replaced by the Distract Action (kept their attack animations because they're cool, though)
@@ -66,6 +68,7 @@
     <summary>List of Spells with surface interaction changed</summary>
     <p>
 
+      - Chromatic Orb
       - Firebolt
       - Produce Flame
       - Ray of Frost
@@ -124,10 +127,10 @@
 
 ## Global changes
 * Changes Initiative Dice Roll from 1d4 to 1d20
-* Extra Attack: 
+* Extra Attack:
   - Multiple sources no longer stack (Martial, Warlock and Wildshape)
   - Better priority logic on which extra attack to use, when considering War Priest, War Magic and Stalker's Flurry
-  - Crossbows loading property only allows shooting once on an Extra Attack sequence (Crossbow Expert feat ignores the loading property)
+  - Players only: Crossbows loading property only allows shooting once on an Extra Attack sequence (Crossbow Expert feat ignores the loading property)
 * Removes weapon abilities (like Cleave, Smash and Pin Down) from all weapons ⚙️ `weaponSpells`
 * Removes the disadvantage on Strength and Dexterity Saving Throws when Prone, and adds the Disadvantage to Ranged Attack Rolls
 * Gives a Walk passive to players that allows them to toggle between walking and running for cinematic and roleplay purposes (as requested by fmarzullo)

--- a/RAW/Mods/RAW/ScriptExtender/Lua/RAW_Lib.lua
+++ b/RAW/Mods/RAW/ScriptExtender/Lua/RAW_Lib.lua
@@ -42,6 +42,27 @@ function RAW_Set_Concat(set, sep)
     return str
 end
 
+function CentralizedString(text, width)
+    width = width or 70
+    local spaces = (width - string.len(text))//2
+    return string.rep(" ", spaces) .. text
+end
+
+function IsModOptionEnabled(modOption)
+    return modOption == "base" or (ModOptions[modOption] ~= nil and ModOptions[modOption].enabled)
+end
+
+-- Checks if the stat has the parent in its using tree
+function StatHasParent(stat, parentName)
+    if stat.Name == parentName then
+        return true
+    end
+    if stat.Using ~= nil and stat.Using ~= "" then
+        return StatHasParent(Ext.Stats.Get(stat.Using), parentName)
+    end
+    return false
+end
+
 -- Print only if the value is set (not commented) on the table
 RAW_PrintTable_ModOptions = 0
 RAW_PrintTable_CharacterPassives = 1
@@ -65,14 +86,4 @@ function RAW_PrintIfDebug(text, debug)
             _D(text)
         end
     end
-end
-
-function CentralizedString(text, width)
-    width = width or 70
-    local spaces = (width - string.len(text))//2
-    return string.rep(" ", spaces) .. text
-end
-
-function IsModOptionEnabled(modOption)
-    return modOption == "base" or (ModOptions[modOption] ~= nil and ModOptions[modOption].enabled)
 end

--- a/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_CharacterPassives.lua
+++ b/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_CharacterPassives.lua
@@ -1,7 +1,11 @@
 local function RAW_AddCharacterDefaultPassives(char)
-    for _, passive in pairs(ENUM_RAW_CharacterDefaultPassives) do
-        RAW_PrintIfDebug("\tAdding passive: " .. passive, RAW_PrintTable_CharacterPassives)
-        char.Passives = passive .. ";" .. char.Passives
+    for parent, passives in pairs(ENUM_RAW_CharacterDefaultPassives) do
+        if parent == "all" or StatHasParent(char, parent) then
+            for _, passive in pairs(passives) do
+                RAW_PrintIfDebug("\tAdding passive: " .. passive, RAW_PrintTable_CharacterPassives)
+                char.Passives = passive .. ";" .. char.Passives
+            end
+        end
     end
     RAW_PrintIfDebug("\tPassives: " .. char.Passives, RAW_PrintTable_CharacterPassives)
 end

--- a/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_CharacterPassives_Model.lua
+++ b/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_CharacterPassives_Model.lua
@@ -1,3 +1,9 @@
 ENUM_RAW_CharacterDefaultPassives = {
-    "RAW_OnTurnTracker",
+    ["all"] = {
+        "RAW_OnTurnTracker",
+    },
+    ["_Hero"] = {
+        "RAW_Loading_Block_ExtraAttack",
+        "RAW_Walk",
+    },
 }

--- a/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_Spells_BonusAction.lua
+++ b/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_Spells_BonusAction.lua
@@ -24,9 +24,12 @@ function RAW_Spells_BonusAction()
 
     for _, name in pairs(Ext.Stats.GetStats("Character")) do
         local char = Ext.Stats.Get(name)
-        RAW_PrintIfDebug("\nCharacter: " .. name, RAW_PrintTable_Spells_BonusAction)
 
-        RAW_AddCharacterBonusActionSpellPassives(char)
+        -- Temporarily giving the passives just to players
+        if StatHasParent(char, "_Hero") then
+            RAW_PrintIfDebug("\nCharacter: " .. name, RAW_PrintTable_Spells_BonusAction)
+            RAW_AddCharacterBonusActionSpellPassives(char)
+        end
     end
 
     Ext.Utils.Print("\n" .. CentralizedString("Finished the the application of Bonus Action Spell Rules"))

--- a/RAW/Mods/RAW/meta.lsx
+++ b/RAW/Mods/RAW/meta.lsx
@@ -21,7 +21,7 @@
                     <attribute id="Tags" type="LSString" value=""/>
                     <attribute id="Type" type="FixedString" value="Add-on"/>
                     <attribute id="UUID" type="FixedString" value="f19c68ed-70be-4c3d-b610-e94afc5c5103"/>
-                    <attribute id="Version64" type="int64" value="108086391056891904"/>
+                    <attribute id="Version64" type="int64" value="108086393204375552"/>
                     <children>
                         <node id="PublishVersion">
                             <attribute id="Version64" type="int64" value="36028797018963968"/>

--- a/RAW/Public/RAW/Stats/Generated/Data/CharacterPassives.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/CharacterPassives.txt
@@ -1,8 +1,8 @@
+// Passives given by Mods\RAW\ScriptExtender\Lua\StatsLoaded\RAW_CharacterPassives.lua
+
 // ------------------------------------------------------
 // -------------------- Turn Tracker --------------------
 // ------------------------------------------------------
-
-// Passive added to all characters by Mods\RAW\ScriptExtender\Lua\StatsLoaded\RAW_CharacterPassives.lua
 
 new entry "RAW_OnTurnTracker"
 type "PassiveData"

--- a/RAW/Public/RAW/Stats/Generated/Data/Player.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/Player.txt
@@ -1,12 +1,6 @@
-new entry "_Hero"
-type "Character"
-using "_Hero"
-data "Passives" "ShortResting;NonLethal;WeaponThrow;Perform;AttackOfOpportunity;DarknessRules;CombatStartAttack;RAW_Walk;RAW_Loading_Block_ExtraAttack"
-
-new entry "ORIGIN_Karlach"
-type "Character"
-using "ORIGIN_Karlach"
-data "Passives" "ShortResting;NonLethal;WeaponThrow;Perform;AttackOfOpportunity;DarknessRules;CombatStartAttack;ORI_Karlach_SweatImmune;RAW_Walk;RAW_Loading_Block_ExtraAttack"
+// Passives given by Mods\RAW\ScriptExtender\Lua\StatsLoaded\RAW_CharacterPassives.lua
+// They're only given to Character entries that have "_Hero" in their "Using" tree,
+//   as per defined on Mods\RAW\ScriptExtender\Lua\StatsLoaded\RAW_CharacterPassives_Model.lua
 
 // ----------------------------------------------------------
 // -------------------- Loading Crossbow --------------------

--- a/RAW/Public/RAW/Stats/Generated/Data/Spells_BonusAction.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/Spells_BonusAction.txt
@@ -2,6 +2,9 @@
 // -------------------- Bonus Action --------------------
 // ------------------------------------------------------
 
+// Depends on RAW_BonusActionSpellPoint and RAW_NotBonusActionSpellPoint created by
+//   Public\RAW\ActionResourceDefinitions\ActionResourceDefinitions.lsx
+
 new entry "RAW_BonusActionSpells"
 type "PassiveData"
 data "Properties" "IsHidden"

--- a/RAW/Public/RAW/Stats/Generated/Data/Spells_SurfaceRemoval.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/Spells_SurfaceRemoval.txt
@@ -13,6 +13,275 @@ data "StatusType" "BOOST"
 data "StackId" "RAW_SURFACECHANGE_HELPER"
 data "StatusPropertyFlags" "DisableOverhead;DisableCombatlog;DisablePortraitIndicator"
 
+// -------------------------------------------------------
+// -------------------- Chromatic Orb --------------------
+// -------------------------------------------------------
+
+// Removes status application and surface creation (but keeps surface interaction if targeting it directly)
+// PS.: Thunder is missing because it was already 3d8 without surfaces in Vanilla
+
+new entry "Projectile_ChromaticOrb"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb"
+data "SpellProperties" ""
+
+new entry "Projectile_ChromaticOrb_Acid"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid"
+data "SpellProperties" ""
+data "SpellSuccess" "DealDamage(3d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(3d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Acid_2"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_2"
+data "SpellSuccess" "DealDamage(4d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(4d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Acid_3"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_3"
+data "SpellSuccess" "DealDamage(5d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(5d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Acid_4"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_4"
+data "SpellSuccess" "DealDamage(6d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(6d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Acid_5"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_5"
+data "SpellSuccess" "DealDamage(7d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(7d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Acid_6"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_6"
+data "SpellSuccess" "DealDamage(8d8,Acid,Magical)"
+data "TooltipDamageList" "DealDamage(8d8,Acid)"
+
+new entry "Projectile_ChromaticOrb_Cold"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Freeze)"
+data "SpellSuccess" "DealDamage(3d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(3d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Cold_2"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_2"
+data "SpellSuccess" "DealDamage(4d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(4d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Cold_3"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_3"
+data "SpellSuccess" "DealDamage(5d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(5d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Cold_4"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_4"
+data "SpellSuccess" "DealDamage(6d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(6d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Cold_5"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_5"
+data "SpellSuccess" "DealDamage(7d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(7d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Cold_6"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_6"
+data "SpellSuccess" "DealDamage(8d8,Cold,Magical);RemoveStatus(BURNING)"
+data "TooltipDamageList" "DealDamage(8d8,Cold)"
+
+new entry "Projectile_ChromaticOrb_Fire"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Ignite);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Melt);"
+data "SpellSuccess" "DealDamage(3d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(3d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Fire_2"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_2"
+data "SpellSuccess" "DealDamage(4d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(4d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Fire_3"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_3"
+data "SpellSuccess" "DealDamage(5d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(5d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Fire_4"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_4"
+data "SpellSuccess" "DealDamage(6d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(6d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Fire_5"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_5"
+data "SpellSuccess" "DealDamage(7d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(7d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Fire_6"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_6"
+data "SpellSuccess" "DealDamage(8d8,Fire,Magical)"
+data "TooltipDamageList" "DealDamage(8d8,Fire)"
+
+new entry "Projectile_ChromaticOrb_Lightning"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Electrify)"
+data "SpellSuccess" "DealDamage(3d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(3d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Lightning_2"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_2"
+data "SpellSuccess" "DealDamage(4d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(4d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Lightning_3"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_3"
+data "SpellSuccess" "DealDamage(5d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(5d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Lightning_4"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_4"
+data "SpellSuccess" "DealDamage(6d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(6d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Lightning_5"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_5"
+data "SpellSuccess" "DealDamage(7d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(7d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Lightning_6"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_6"
+data "SpellSuccess" "DealDamage(8d8,Lightning,Magical)"
+data "TooltipDamageList" "DealDamage(8d8,Lightning)"
+
+new entry "Projectile_ChromaticOrb_Poison"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison"
+data "SpellProperties" ""
+data "SpellSuccess" "DealDamage(3d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(3d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Poison_2"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_2"
+data "SpellSuccess" "DealDamage(4d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(4d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Poison_3"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_3"
+data "SpellSuccess" "DealDamage(5d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(5d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Poison_4"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_4"
+data "SpellSuccess" "DealDamage(6d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(6d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Poison_5"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_5"
+data "SpellSuccess" "DealDamage(7d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(7d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Poison_6"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_6"
+data "SpellSuccess" "DealDamage(8d8,Poison,Magical)"
+data "TooltipDamageList" "DealDamage(8d8,Poison)"
+
+new entry "Projectile_ChromaticOrb_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Monk"
+data "ContainerSpells" "Projectile_ChromaticOrb_Acid_Monk;Projectile_ChromaticOrb_Cold_Monk;Projectile_ChromaticOrb_Fire_Monk;Projectile_ChromaticOrb_Lightning_Monk;Projectile_ChromaticOrb_Poison_Monk;Projectile_ChromaticOrb_Thunder_Monk"
+data "SpellProperties" "ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+new entry "Projectile_ChromaticOrb_Acid_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Acid_Monk"
+data "SpellProperties" "ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+new entry "Projectile_ChromaticOrb_Cold_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Cold_Monk"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Freeze);ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+new entry "Projectile_ChromaticOrb_Fire_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Fire_Monk"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Ignite);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Melt);ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+new entry "Projectile_ChromaticOrb_Lightning_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Lightning_Monk"
+data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Electrify);ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+new entry "Projectile_ChromaticOrb_Poison_Monk"
+type "SpellData"
+data "SpellType" "Projectile"
+using "Projectile_ChromaticOrb_Poison_Monk"
+data "SpellProperties" "ApplyStatus(SELF,MARTIAL_ARTS_BONUS_UNARMED_STRIKE,100,1)"
+
+// --------------------------------------------------
+// -------------------- Firebolt --------------------
+// --------------------------------------------------
+
 new entry "Projectile_FireBolt"
 type "SpellData"
 data "SpellType" "Projectile"
@@ -21,17 +290,29 @@ data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:
 
 // Produce Flame is on Spells.txt since it has more changes outside the surface interaction
 
+// ------------------------------------------------------
+// -------------------- Ray of Frost --------------------
+// ------------------------------------------------------
+
 new entry "Projectile_RayOfFrost"
 type "SpellData"
 data "SpellType" "Projectile"
 using "Projectile_RayOfFrost"
 data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Freeze);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Douse);"
 
+// -------------------------------------------------------
+// -------------------- Scorching Ray --------------------
+// -------------------------------------------------------
+
 new entry "Projectile_ScorchingRay"
 type "SpellData"
 data "SpellType" "Projectile"
 using "Projectile_ScorchingRay"
 data "SpellProperties" "ApplyStatus(SELF,RAW_SURFACECHANGE_HELPER,100,0);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Ignite);GROUND:IF(not HasStatus('RAW_SURFACECHANGE_HELPER',context.Source)):SurfaceChange(Melt);"
+
+// --------------------------------------------------------
+// -------------------- Shocking Grasp --------------------
+// --------------------------------------------------------
 
 new entry "Target_ShockingGrasp"
 type "SpellData"


### PR DESCRIPTION
- Gives the bonus action spell passives only to players, to avoid an obscure crashing on certain save files with `spells_bonusAction` option turned on
- Changes Chromatic Orb to deal 3d8 base damage and have no surface creation (it still interacts with surfaces if targeting it directly)
- Shifts the player passives to be injected by the Script Extender, thus avoiding the Self Inheritance issue with Karlach (losing the `Using` reference to `_Hero` needed to give her the bonus action spells rule passives)