### PR TITLE
Ranged weapons attunement

### DIFF
--- a/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_Attunement.lua
+++ b/RAW/Mods/RAW/ScriptExtender/Lua/StatsLoaded/RAW_Attunement.lua
@@ -6,9 +6,9 @@ local function RAW_AddAttunement(item)
         useConditionsPrefix = "(" .. item.UseConditions .. ") and "
     end
 
-    -- Attunement items can't be equipped in combat, except weapons (because of thrown weapons)
+    -- Attunement items can't be equipped in combat, except weapons (because of thrown weapons and weapon sets)
     local combatRestriction = "((Player(context.Source) and not Combat(context.Source)) or not Player(context.Source)) and "
-    if item.Slot == "Melee Main Weapon" then
+    if item.Slot == "Melee Main Weapon" or item.Slot == "Ranged Main Weapon" then
         combatRestriction = ""
     end
 


### PR DESCRIPTION
- Also allows ranged weapons to be equipped in combat even if they require attunement, so it's not penalizing for players using the `weaponSets` disabler