### PR TITLE
Fixes Barbarian's Wild Magic Teleport

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -26,6 +26,7 @@ _Developed in partnership with [Eric](https://www.nexusmods.com/baldursgate3/mod
 ## Barbarian (Wild Magic) ⚙️ `barbarian_wildMagic`
 * Level 3: Makes all bonus actions granted by the random outcomes castable in the first round for free (next rounds it still requires a bonus action)
 * Level 3: Shadowy Tendrils random outcome only damages enemies
+* Level 3: Fixes Wild Magic: Teleport applying to everyone around the Barbarian, for some reason (vanilla bug)
 
 ## Concentration Failsafe ⚙️ `concentration_failsafe`
 _Quality of Life feature_

--- a/RAW/Public/RAW/Stats/Generated/Data/Barbarian_WildMagic.txt
+++ b/RAW/Public/RAW/Stats/Generated/Data/Barbarian_WildMagic.txt
@@ -21,3 +21,12 @@ type "SpellData"
 data "SpellType" "Shout"
 using "Shout_WildMagicBarbarian_ShadowyTendrils"
 data "TargetConditions" "Character() and (Self() or Enemy())"
+
+// Fix Vanilla boo-boo
+new entry "Shout_WildMagicBarbarian_Teleport_Activate"
+type "SpellData"
+data "SpellType" "Shout"
+using "Shout_WildMagicBarbarian_Teleport_Activate"
+data "Cooldown" ""
+data "AreaRadius" ""
+data "UseCosts" ""


### PR DESCRIPTION
For some reason, Vanilla applies the status to everyone around the Barbarian when the random outcome happens. It wasn't always like this, seems like some unintended behavior added recently